### PR TITLE
Adds basic throttling to the API

### DIFF
--- a/paint/apps/batch/tests/regression/test_batch_v1.py
+++ b/paint/apps/batch/tests/regression/test_batch_v1.py
@@ -12,5 +12,5 @@ class BatchV1Test(TestCase):
     def test_returns_a_well_formed_batch_when_correct_input_is_given(self):
         """When given valid requirements, the API should return a well-formed batch"""
         c: Client = Client()
-        resp: Response = c.get('/v1/?input={%22colors%22:5,%22customers%22:3,%22demands%22:[[1,1,1],[2,1,0,2,0],[1,5,0]]} ')
+        resp: Response = c.get('/v1/?input={%22colors%22:5,%22customers%22:3,%22demands%22:[[1,1,1],[2,1,0,2,0],[1,5,0]]}')
         self.assertEqual(resp.json(), '1 0 0 0 0')

--- a/paint/apps/batch/views.py
+++ b/paint/apps/batch/views.py
@@ -19,6 +19,7 @@ class BatchV1(APIView):
     This exists for backwards-compatibility
     """
     permission_classes = [permissions.AllowAny] # backwards compatibility
+    throttle_classes = [] # backwards-compatibility - we can remove this to re-enable throttling here
 
     def get(self, request: Request) -> Response:
         """Generate a response using the solver lib"""

--- a/paint/settings/production.py
+++ b/paint/settings/production.py
@@ -79,12 +79,24 @@ INSTALLED_APPS = [
     'paint.apps.history'
 ]
 
+### Batch ### 
+THROTTLE_PERIOD_USER = os.environ.get('BATCH_THROTTLE_RANGE', 'day')
+THROTTLE_COUNT_USER = int(os.environ.get('BATCH_THROTTLE_COUNT', '1000'))
+THROTTLE_USER = f'{THROTTLE_COUNT_USER}/{THROTTLE_PERIOD_USER}'
+
+THROTTLE_PERIOD_ANON = os.environ.get('BATCH_THROTTLE_RANGE', 'day')
+THROTTLE_COUNT_ANON = int(os.environ.get('BATCH_THROTTLE_COUNT', '100'))
+THROTTLE_ANON = f'{THROTTLE_COUNT_ANON}/{THROTTLE_PERIOD_ANON}'
+
 ### Django Rest Framework ###
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': ['rest_framework.authentication.BasicAuthentication'],
     'DEFAULT_PERMISSION_CLASSES': ['rest_framework.permissions.IsAuthenticated'],
-    'DEFAULT_THROTTLE_CLASSES': [] # TODO
+    'DEFAULT_THROTTLE_CLASSES': [
+        'paint.util.throttle.AnonymousThrottle',
+        'paint.util.throttle.UserThrottle'
+    ]
 }
 
 

--- a/paint/util/throttle.py
+++ b/paint/util/throttle.py
@@ -1,0 +1,15 @@
+'''Custom throttle subclasses to allow independent configuration
+
+DRF only allows a DEFAULT_THROTTLE_RATES setting which applies to all
+throttles equally, but we want to be able to configure each one separately.
+'''
+
+from django.conf import settings
+from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
+
+
+class AnonymousThrottle(AnonRateThrottle):
+    rate = settings.THROTTLE_ANON
+
+class UserThrottle(UserRateThrottle):
+    rate = settings.THROTTLE_USER


### PR DESCRIPTION
What does this PR do?
=========================

This commit adds two Throttle classes, AnonymousThrottle and
UserThrottle. They can be configured independently via environment
variables. The v1 batch view has no throttling.

Closes #7 

Why are we doing this?
======================

By default, DRF allows you to configure "default" rate settings for all
throttles. This doesn't fit our use-case, where anonymous users and
authenticated users have different rates applied.

We have exempted the v1 batch view for backwards compatibility.